### PR TITLE
Fix to 3D plane when x and y are free symbols

### DIFF
--- a/spb/series.py
+++ b/spb/series.py
@@ -3262,8 +3262,10 @@ class PlaneSeries(SurfaceBaseSeries):
             xx, yy, zz = zz, yy, xx
         elif (fs == set([y])) or (fs == set([x, y])):
             # parallel to xz plane (normal vector (0, 1, 0))
+            p1_np = np.array(plane.p1, dtype=float)
+            nv_np = np.array(plane.normal_vector, dtype=float)
             s = SurfaceOver2DRangeSeries(
-                plane.p1[1],
+                nv_np.dot(p1_np) / ((nv_np.T @ nv_np) ** 0.5),
                 (x, *self.x_range[1:]),
                 (y, *self.z_range[1:]),
                 "",


### PR DESCRIPTION
Bug found:

plot_geometry(Plane(p,n))

when the free parameters are x and y and the plane does not intersect x=0, y=0. The problem narrowed down to "PlaneSeries.get_data()". 