### PR TITLE
missing line compared to 464

### DIFF
--- a/spb/backends/matplotlib/matplotlib.py
+++ b/spb/backends/matplotlib/matplotlib.py
@@ -469,6 +469,7 @@ class MatplotlibBackend(Plot):
                 self._ax.set_xlim(xlim)
             if ylims and (
                 any(s.is_contour for s in self.series)
+                or any(s.is_vector and (not s.is_3D) for s in self.series)
                 or any(s.is_2Dline and s.is_parametric for s in self.series)
             ):
                 ylims = np.array(ylims)


### PR DESCRIPTION
In the matplotlib backend, one line is missing when updating the ylims (compared to the xlims right above). Updated by matching the second half of the xlims "if-statement" (line 464 in _backends/matplotlib.py_) to the second half of the ylims "if-statement" (line 471 in _backends/matplotlib.py_)

**Result of this missing line**: 2D vector-plots with specified xlims and ylims (or inferred from data) only have their xlims updated. 