### PR TITLE
Fix create colorbar configuring invalid title properties.

### DIFF
--- a/spb/backends/plotly/plotly.py
+++ b/spb/backends/plotly/plotly.py
@@ -372,8 +372,10 @@ class PlotlyBackend(Plot):
         self._colorbar_counter += 1
         return dict(
             x=1 + self._cbs * k,
-            title=label,
-            titleside="right",
+            title=dict(
+                text=label,
+                side="right"
+            ),
             # scale down the color bar to make room for legend
             len=(
                 self._cbsdf if (sc and (self.legend or (self.legend is None)))


### PR DESCRIPTION
The `PlotlyBackend` currently sets a property named `titleside` in its `_create_colorbar` method, althrough according to the plotly docs, [no such property exists](https://plotly.github.io/plotly.py-docs/generated/plotly.graph_objects.surface.html#plotly.graph_objects.surface.ColorBar).

This PR changes the incorrectly named properties returned by the `_create_colorbar` method to be compatible with the newest supported plotly version.

This should fix #48 